### PR TITLE
Add GET /api/users endpoint for listing active users

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bin/rails server -p 3000
+web: bin/rails server -p 3001
 css: bin/rails dartsass:watch
 keycloak: docker run --rm --network cloakman --name cloakman-keycloak --publish 8080:8080 --env KC_BOOTSTRAP_ADMIN_USERNAME=keycloak --env KC_BOOTSTRAP_ADMIN_PASSWORD=keycloak --env KC_DB_USERNAME=sa --volume cloakman_keycloak:/opt/keycloak/data --volume $PWD/keycloak/providers:/opt/keycloak/providers --volume $PWD/keycloak/themes/ddbj:/opt/keycloak/themes/ddbj keycloak/keycloak:26.3.1 start-dev
 openldap: docker run --rm --network cloakman --name cloakman-openldap --publish 1389:1389 --env LDAP_ROOT=dc=ddbj,dc=nig,dc=ac,dc=jp --env LDAP_SKIP_DEFAULT_TREE=yes --env LDAP_ALLOW_ANON_BINDING=no --env LDAP_CONFIG_ADMIN_ENABLED=yes --env BITNAMI_DEBUG=true --volume cloakman_openldap:/bitnami/openldap --volume $PWD/openldap/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d --volume $PWD/openldap/schemas:/schemas --volume $PWD/openldap/ldifs:/ldifs bitnamilegacy/openldap:2.6.10

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,4 +1,27 @@
 class API::UsersController < API::BaseController
+  def index
+    filter = Net::LDAP::Filter.eq('objectClass', 'ddbjUser') &
+      Net::LDAP::Filter.eq('inetUserStatus', 'active')
+
+    if query = params[:query].presence
+      filter = filter & %w[uid mail commonName].map {|attr|
+        Net::LDAP::Filter.contains(attr, query)
+      }.inject(:|)
+    end
+
+    users = User.search(filter).sort_by(&:id).map {|user|
+      {
+        uid:                 user.id,
+        full_name:           user.full_name,
+        email:               user.email,
+        organization:        user.organization,
+        account_type_number: user.account_type_number.to_s
+      }
+    }
+
+    render json: users
+  end
+
   def create
     user = User.new(user_params)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
-    resources :users, only: :create
+    resources :users, only: %i[index create]
   end
 
   get 'up' => 'rails/health#show', as: :rails_health_check

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -1,6 +1,46 @@
 require 'test_helper'
 
 class API::UsersControllerTest < ActionDispatch::IntegrationTest
+  test 'should list active users' do
+    FactoryBot.create :user, id: 'alice',   first_name: 'Alice',   last_name: 'Liddell',  organization: 'Wonderland'
+    FactoryBot.create :user, id: 'bob',     first_name: 'Bob',     last_name: 'Builder',  organization: 'Construction Co'
+    FactoryBot.create :user, id: 'charlie', first_name: 'Charlie', last_name: 'Chaplin',  organization: 'Silent Films', inet_user_status: :inactive
+
+    get api_users_path, headers: {Authorization: 'Bearer TOKEN_ONE'}
+
+    assert_response :ok
+
+    res = JSON.parse(response.body, symbolize_names: true)
+
+    assert_equal %w[alice bob], res.pluck(:uid)
+    assert_equal({
+      uid:                 'alice',
+      full_name:           'Alice Liddell',
+      email:               'alice@example.com',
+      organization:        'Wonderland',
+      account_type_number: 'general'
+    }, res.first)
+  end
+
+  test 'filters users by query' do
+    FactoryBot.create :user, id: 'alice', first_name: 'Alice', last_name: 'Liddell'
+    FactoryBot.create :user, id: 'bob',   first_name: 'Bob',   last_name: 'Builder'
+
+    get api_users_path, params: {query: 'ali'}, headers: {Authorization: 'Bearer TOKEN_ONE'}
+
+    assert_response :ok
+
+    res = JSON.parse(response.body, symbolize_names: true)
+
+    assert_equal %w[alice], res.pluck(:uid)
+  end
+
+  test 'rejects unauthenticated requests to index' do
+    get api_users_path
+
+    assert_response :unauthorized
+  end
+
   test 'should create user' do
     post api_users_path, **{
       headers: {


### PR DESCRIPTION
## Summary

- ddbj-repository の admin 画面でユーザ一覧から proxy login する機能のために、cloakman に user 検索 API を追加
- 既存の `API::BaseController`（HTTP Token 認証）を流用し、`GET /api/users` で active な ddbjUser を `query` で uid/mail/cn 部分一致検索できるようにする
- `User.search` の `size: 100` 制約はそのままなので、レスポンスも最大 100 件まで
- 開発 web サーバを 3000 → 3001 に変更（ddbj-repository と同居できるように）

## Test plan

- [ ] `bin/dev` で起動後、`/admin/api_keys` で APIKey を発行
- [ ] `curl -H "Authorization: Bearer <token>" http://localhost:3001/api/users` で active ユーザが返ることを確認
- [ ] `?query=...` で uid/email/名前 で絞り込みが効くことを確認
- [ ] 無認証 / 不正トークンで 401 になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)