### PR TITLE
Support filtering /api/users by uids

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,15 +1,27 @@
 class API::UsersController < API::BaseController
   def index
-    filter = Net::LDAP::Filter.eq('objectClass', 'ddbjUser') &
-      Net::LDAP::Filter.eq('inetUserStatus', 'active')
+    filter = Net::LDAP::Filter.eq('inetUserStatus', 'active')
+    size   = 100
 
     if query = params[:query].presence
-      filter = filter & %w[uid mail commonName].map {|attr|
+      filter &= %w[uid mail commonName].map {|attr|
         Net::LDAP::Filter.contains(attr, query)
       }.inject(:|)
     end
 
-    users = User.search(filter).sort_by(&:id).map {|user|
+    if params.key?(:uids)
+      uids = Array(params[:uids]).select(&:present?)
+
+      if uids.empty?
+        render json: []
+        return
+      end
+
+      filter &= uids.map {|uid| Net::LDAP::Filter.eq('uid', uid) }.inject(:|)
+      size    = uids.size
+    end
+
+    users = User.search(filter, size:).sort_by(&:id).map {|user|
       {
         uid:                 user.id,
         full_name:           user.full_name,

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -10,12 +10,8 @@ class API::UsersController < API::BaseController
     end
 
     if params.key?(:uids)
-      uids = Array(params[:uids]).select(&:present?)
-
-      if uids.empty?
-        render json: []
-        return
-      end
+      uids = Array.wrap(params[:uids]).compact_blank
+      return render(json: []) if uids.empty?
 
       filter &= uids.map {|uid| Net::LDAP::Filter.eq('uid', uid) }.inject(:|)
       size    = uids.size

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -147,7 +147,7 @@ class User < LDAPEntry
     self.home_directory ||= "/submission/#{id}"
   end
 
-  def self.search(filter)
+  def self.search(filter, size: 100)
     filter = Net::LDAP::Filter.eq('objectClass', 'ddbjUser') & filter
 
     LDAP.connection.assert_call(:search, **{
@@ -156,7 +156,7 @@ class User < LDAPEntry
       attributes:                    ldap_to_model_map.keys,
       return_operational_attributes: true,
       filter:,
-      size:                          100
+      size:
     }).map { from_entry(it) }
   end
 

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -35,6 +35,32 @@ class API::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal %w[alice], res.pluck(:uid)
   end
 
+  test 'filters users by uids' do
+    FactoryBot.create :user, id: 'alice',   first_name: 'Alice',   last_name: 'Liddell'
+    FactoryBot.create :user, id: 'bob',     first_name: 'Bob',     last_name: 'Builder'
+    FactoryBot.create :user, id: 'charlie', first_name: 'Charlie', last_name: 'Chaplin'
+
+    get api_users_path, params: {uids: %w[alice charlie zzz]}, headers: {Authorization: 'Bearer TOKEN_ONE'}
+
+    assert_response :ok
+
+    res = JSON.parse(response.body, symbolize_names: true)
+
+    assert_equal %w[alice charlie], res.pluck(:uid)
+  end
+
+  test 'returns empty array when uids is empty' do
+    FactoryBot.create :user, id: 'alice', first_name: 'Alice', last_name: 'Liddell'
+
+    get api_users_path, params: {uids: []}, headers: {Authorization: 'Bearer TOKEN_ONE'}
+
+    assert_response :ok
+
+    res = JSON.parse(response.body, symbolize_names: true)
+
+    assert_empty res
+  end
+
   test 'rejects unauthenticated requests to index' do
     get api_users_path
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,8 +4,10 @@ require 'rails/test_help'
 
 module ActiveSupport
   class TestCase
-    # Run tests in parallel with specified workers
-    parallelize(workers: :number_of_processors)
+    # LDAP and Redis are shared across workers, so parallel runs race on
+    # reset_ldap (destroy/create) and reset_redis. Serialize to keep tests
+    # deterministic.
+    parallelize(workers: 1)
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all


### PR DESCRIPTION
## Summary

- `GET /api/users` で `uids` パラメータを受け取り、指定された uid に絞った結果を返す
- 既存の `query` パラメータと併用可能（AND で適用）
- `User.search` に `size:` 引数を追加し、`uids` 指定時は `uids.size` を上限に渡す（既存の 100 件キャップを実質回避）

## Why

ddbj-repository 側でユーザ一覧を「自分の users テーブルに登録されているユーザのみ」に変更するため、ローカルで管理している uid 群の追加情報（full_name / email / organization / account_type_number）を cloakman から bulk で取得したい。

## Test plan

- [x] `test/controllers/api/users_controller_test.rb` で uids 指定時のフィルタと空配列時の挙動を追加（全 7 件 pass）