### PR TITLE
Split /api/users uids lookup into its own action

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,7 +1,6 @@
 class API::UsersController < API::BaseController
   def index
     filter = Net::LDAP::Filter.eq('inetUserStatus', 'active')
-    size   = 100
 
     if query = params[:query].presence
       filter &= %w[uid mail commonName].map {|attr|
@@ -9,25 +8,17 @@ class API::UsersController < API::BaseController
       }.inject(:|)
     end
 
-    if params.key?(:uids)
-      uids = Array.wrap(params[:uids]).compact_blank
-      return render(json: []) if uids.empty?
+    render json: serialize(User.search(filter))
+  end
 
-      filter &= uids.map {|uid| Net::LDAP::Filter.eq('uid', uid) }.inject(:|)
-      size    = uids.size
-    end
+  def lookup
+    uids = Array.wrap(params[:uids]).compact_blank
+    return render(json: []) if uids.empty?
 
-    users = User.search(filter, size:).sort_by(&:id).map {|user|
-      {
-        uid:                 user.id,
-        full_name:           user.full_name,
-        email:               user.email,
-        organization:        user.organization,
-        account_type_number: user.account_type_number.to_s
-      }
-    }
+    filter = Net::LDAP::Filter.eq('inetUserStatus', 'active') &
+      uids.map {|uid| Net::LDAP::Filter.eq('uid', uid) }.inject(:|)
 
-    render json: users
+    render json: serialize(User.search(filter, size: uids.size))
   end
 
   def create
@@ -41,6 +32,18 @@ class API::UsersController < API::BaseController
   end
 
   private
+
+  def serialize(users)
+    users.sort_by(&:id).map {|user|
+      {
+        uid:                 user.id,
+        full_name:           user.full_name,
+        email:               user.email,
+        organization:        user.organization,
+        account_type_number: user.account_type_number.to_s
+      }
+    }
+  end
 
   def user_params
     params.expect(user: [

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,6 +1,6 @@
 class API::UsersController < API::BaseController
   def index
-    filter = Net::LDAP::Filter.eq('inetUserStatus', 'active')
+    filter = active_filter
 
     if query = params[:query].presence
       filter &= %w[uid mail commonName].map {|attr|
@@ -15,8 +15,7 @@ class API::UsersController < API::BaseController
     uids = Array.wrap(params[:uids]).compact_blank
     return render(json: []) if uids.empty?
 
-    filter = Net::LDAP::Filter.eq('inetUserStatus', 'active') &
-      uids.map {|uid| Net::LDAP::Filter.eq('uid', uid) }.inject(:|)
+    filter = active_filter & uids.map {|uid| Net::LDAP::Filter.eq('uid', uid) }.inject(:|)
 
     render json: serialize(User.search(filter, size: uids.size))
   end
@@ -32,6 +31,8 @@ class API::UsersController < API::BaseController
   end
 
   private
+
+  def active_filter = Net::LDAP::Filter.eq('inetUserStatus', 'active')
 
   def serialize(users)
     users.sort_by(&:id).map {|user|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,11 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
-    resources :users, only: %i[index create]
+    resources :users, only: %i[index create] do
+      collection do
+        get :lookup
+      end
+    end
   end
 
   get 'up' => 'rails/health#show', as: :rails_health_check

--- a/test/controllers/api/users_controller_test.rb
+++ b/test/controllers/api/users_controller_test.rb
@@ -35,12 +35,18 @@ class API::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal %w[alice], res.pluck(:uid)
   end
 
-  test 'filters users by uids' do
+  test 'rejects unauthenticated requests to index' do
+    get api_users_path
+
+    assert_response :unauthorized
+  end
+
+  test 'lookup returns users matching the given uids' do
     FactoryBot.create :user, id: 'alice',   first_name: 'Alice',   last_name: 'Liddell'
     FactoryBot.create :user, id: 'bob',     first_name: 'Bob',     last_name: 'Builder'
     FactoryBot.create :user, id: 'charlie', first_name: 'Charlie', last_name: 'Chaplin'
 
-    get api_users_path, params: {uids: %w[alice charlie zzz]}, headers: {Authorization: 'Bearer TOKEN_ONE'}
+    get lookup_api_users_path, params: {uids: %w[alice charlie zzz]}, headers: {Authorization: 'Bearer TOKEN_ONE'}
 
     assert_response :ok
 
@@ -49,10 +55,10 @@ class API::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal %w[alice charlie], res.pluck(:uid)
   end
 
-  test 'returns empty array when uids is empty' do
+  test 'lookup returns an empty array when uids is empty' do
     FactoryBot.create :user, id: 'alice', first_name: 'Alice', last_name: 'Liddell'
 
-    get api_users_path, params: {uids: []}, headers: {Authorization: 'Bearer TOKEN_ONE'}
+    get lookup_api_users_path, params: {uids: []}, headers: {Authorization: 'Bearer TOKEN_ONE'}
 
     assert_response :ok
 
@@ -61,8 +67,8 @@ class API::UsersControllerTest < ActionDispatch::IntegrationTest
     assert_empty res
   end
 
-  test 'rejects unauthenticated requests to index' do
-    get api_users_path
+  test 'rejects unauthenticated requests to lookup' do
+    get lookup_api_users_path
 
     assert_response :unauthorized
   end


### PR DESCRIPTION
## Summary

- `GET /api/users` を query 検索専用に戻し、uid 指定の bulk lookup は `GET /api/users/lookup` という別アクションに分離
- 共通の user シリアライズ処理を private method `serialize` に抽出

## Why

#391 で `/api/users#index` に `uids` パラメータを足したが、「query と uids を同じエンドポイントに同居させると、片方/両方/どちらも無しの 4 通りの意味が暗黙になる」という指摘を受けて、対称的な 2 アクションに分割します。

## Depends-on / Required-after

- ddbj/ddbj-repository#1850 をこの PR にあわせて更新します（`CloakmanClient` の呼び先を `/api/users/lookup` に切り替え）。マージ順は本 PR → デプロイ → ddbj-repository PR の順で。

## Test plan

- [x] `test/controllers/api/users_controller_test.rb` を `lookup` 用に書き直し（pass）
- [x] full suite pass（53 runs）